### PR TITLE
Set timesort to null by default

### DIFF
--- a/smartdata.php
+++ b/smartdata.php
@@ -867,7 +867,7 @@ class test_data_generator {
             'repeats' => 0,
             'timestart' => null,
             'timeduration' => 0,
-            'timesort' => 0,
+            'timesort' => null,
             'type'  => CALENDAR_EVENT_TYPE_STANDARD,
             'uuid' => null,
         ];


### PR DESCRIPTION
* Setting timesort to 0 for the generated events will cause the events to be sorted by timesort instead of the timestart. This messes up the ordering of the events displayed in the upcoming events view.